### PR TITLE
feat(board): create initial page and comment component

### DIFF
--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -1,0 +1,29 @@
+// src/app/board/page.tsx
+
+import { CommentItem } from "~/components/features/board/CommentItem";
+
+// 表示確認用ダミーデータ
+const mockComments = [
+    { id: 1, authorName: "琉大生A", content: "初コメントです", createdAt: new Date() },
+    { id: 2, authorName: "琉大生B", content: "二番目のコメントです", createdAt: new Date() },
+    { id: 3, authorName: "琉大生C", content: "三番目のコメントです", createdAt: new Date() },
+];
+
+export default function BoardPage() {
+    return (
+        <main className="min-h-screen bg-gray-100 p-8">
+            <h1 className="text-3xl font-bold">ゆんたく掲示板</h1>
+
+            <div className="mt-8 space-y-4">
+                {mockComments.map((comment) => (
+                    <CommentItem
+                        key={comment.id}
+                        authorName={comment.authorName}
+                        content={comment.content}
+                        createdAt={comment.createdAt}
+                    />
+                ))}
+            </div>
+        </main>
+    );
+};

--- a/src/components/features/board/CommentItem.tsx
+++ b/src/components/features/board/CommentItem.tsx
@@ -1,0 +1,28 @@
+// src/components/features/board/CommentItem.tsx
+
+import type { FC } from 'react';
+
+//データを受け取るための型定義
+type Props = {
+    authorName: string;
+    content: string;
+    createdAt: Date;
+};
+
+export const CommentItem: FC<Props> = ({ authorName, content, createdAt: _createdAt }) => {
+    return (
+        <div className="rounded-lg border bg-white p-4">
+            <p className="text-sm font-bold text-gray-700">{ authorName }</p>
+            <p className="mt-2 text-gray-800">{ content }</p>
+            <p className="mt-1 text-xs text-gray-500">
+                {new Intl.DateTimeFormat('ja-JP', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                }).format(_createdAt)}
+            </p>
+        </div>
+    );
+};


### PR DESCRIPTION
## 概要
掲示板機能のUIの雛形を作成した。
ひとまずダミーデータを表示するところまで実装している。

## やったこと
- 掲示板ページ(`/board`)のルーティングと基本レイアウトを作成
- 1コメントを表示するための`CommentItem`コンポーネントを作成

## 確認して欲しいこと
- コンポーネントの分け方や命令規則はこれで問題ないか
- デザインやUI/UXは問題ないか
- 考慮漏れや改善点などないか

確認お願いします。